### PR TITLE
 Change Hyperion core dependencies from implementation to api

### DIFF
--- a/foqa/build.gradle
+++ b/foqa/build.gradle
@@ -2,7 +2,7 @@ androidPublish.artifactId = 'foqa'
 description = "Various Quality Assurance utilities to be included in QA/testing variants of Android apps"
 
 dependencies {
-    implementation "com.willowtreeapps.hyperion:hyperion-core:$versions.hyperion"
+    api "com.willowtreeapps.hyperion:hyperion-core:$versions.hyperion"
     implementation "com.willowtreeapps.hyperion:hyperion-attr:$versions.hyperion"
     implementation "com.willowtreeapps.hyperion:hyperion-measurement:$versions.hyperion"
     implementation "com.willowtreeapps.hyperion:hyperion-disk:$versions.hyperion"


### PR DESCRIPTION
This allows using Hyperion APIs, such as 
```kotlin
Hyperion.open(...)
```