### PR TITLE
Use stable version of AGP 7.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@ object Dependencies {
     const val deviceNames = "com.jaredrummler:android-device-names:2.0.0"
     const val debugDb = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:1.0.6"
     const val multidex = "androidx.multidex:multidex:2.0.1"
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0-alpha13"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
     const val publishGradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
     const val okHttpBom = "com.squareup.okhttp3:okhttp-bom:4.9.2"


### PR DESCRIPTION
Aktualnie wyszło stabilne 7.1.0 i nie możemy w CCC skompilowac bo AgpVersionCompatibilityRule nie potrafi stwierdzic czy 7.1.0-alpha jest kompatybilne z 7.1.0