### PR TITLE
Bump agp to version 7.1.1

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@ object Dependencies {
     const val deviceNames = "com.jaredrummler:android-device-names:2.0.0"
     const val debugDb = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:1.0.6"
     const val multidex = "androidx.multidex:multidex:2.0.1"
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.0"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.1.1"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
     const val publishGradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
     const val okHttpBom = "com.squareup.okhttp3:okhttp-bom:4.9.2"


### PR DESCRIPTION
W sumie nigdy wcześniej sie z takim problemem nie spotkałem że libka ma inną wersje agp i to już jest problem. Znając zycie wiekszosc naszych zależnosci (w CCC) jest zbudowana ze starsza wersja gradla niż to co mamy w CCC w momencie podbicia wersji gradla, bo podbijamy praktycznie w dniu release-u, wiec czemu tylko z tą libką jest problem? 
Musze przeanalizowac konfiguracje bo moze po prostu nie rozumiem co ten projekt robi :D