### PR TITLE
Don't force consumers to use jetifier

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -23,7 +23,10 @@ object Dependencies {
     const val hyperionAppInfo = "com.star-zero:hyperion-appinfo:2.0.0"
     const val chucker = "com.github.ChuckerTeam.Chucker:library:3.5.2"
     const val deviceNames = "com.jaredrummler:android-device-names:2.1.0"
-    const val debugDb = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:1.0.6"
+
+    // debug-db uses legacy appcompat dependencies, using @aar will not force consumers to run jetifier on their side
+    const val debugDb = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:1.0.6@aar"
+
     const val multidex = "androidx.multidex:multidex:2.0.1"
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.3.1"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"

--- a/foqa/build.gradle.kts
+++ b/foqa/build.gradle.kts
@@ -22,7 +22,11 @@ dependencies {
     api(Dependencies.chucker)
     api(platform(Dependencies.okHttpBom))
     api(Dependencies.okHttp)
-    implementation(Dependencies.debugDb)
+    implementation(Dependencies.debugDb) {
+        // debugDb uses legacy appcompat dependencies, making it transitive will not force consumers
+        // to run jetifier on their side
+        isTransitive = true
+    }
 
     implementation(project(":device_info_plugin"))
     implementation(project(":font_scale_plugin"))


### PR DESCRIPTION
Taki mój pomysł na rozwiązanie problemu w CCC.
NIE WIEM CZY NA 100% TO ROZWIĄŻE PROBLEM.

Nie wiem czy najlesze podejście ale dla FoQA taki jetifier nie jest jakimś spowalniaczem i dzięki tej zmianie potrzebna zależność już bedzie przerobiona na androidX przez co projekty używające FoQA nie będą musiały tego robić.

Może jest jakaś nowsza biblioteka którą możnaby zastąpić problematyczną zależność ale nie mam teraz możliwości i czasu żeby szukać a przede wszystkim wdrażać się w projekt żeby dobrze zmigrować na nową libkę 🤷 