### PR TITLE
Revert "Don't force consumers to use jetifier"

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -23,10 +23,7 @@ object Dependencies {
     const val hyperionAppInfo = "com.star-zero:hyperion-appinfo:2.0.0"
     const val chucker = "com.github.ChuckerTeam.Chucker:library:3.5.2"
     const val deviceNames = "com.jaredrummler:android-device-names:2.1.0"
-
-    // debug-db uses legacy appcompat dependencies, using @aar will not force consumers to run jetifier on their side
-    const val debugDb = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:1.0.6@aar"
-
+    const val debugDb = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:1.0.6"
     const val multidex = "androidx.multidex:multidex:2.0.1"
     const val androidGradlePlugin = "com.android.tools.build:gradle:7.3.1"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"

--- a/foqa/build.gradle.kts
+++ b/foqa/build.gradle.kts
@@ -22,11 +22,7 @@ dependencies {
     api(Dependencies.chucker)
     api(platform(Dependencies.okHttpBom))
     api(Dependencies.okHttp)
-    implementation(Dependencies.debugDb) {
-        // debugDb uses legacy appcompat dependencies, making it transitive will not force consumers
-        // to run jetifier on their side
-        isTransitive = true
-    }
+    implementation(Dependencies.debugDb)
 
     implementation(project(":device_info_plugin"))
     implementation(project(":font_scale_plugin"))


### PR DESCRIPTION
nie działa i to jednak było głupie bo notacja @aar pobiera tylko aar libki (bez pom-a definiujacego zaleznosci) ale transitive=true nadal je pobiera i one są. Gdyby nie transitive to w CCC musielibysmy te zaleznosci dostarczyc ale nadal byłyby to legacy zależności.